### PR TITLE
Fixes wrong localhost port in quickstart guide

### DIFF
--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -16,7 +16,7 @@ Once you have Docker up and running, follow the next steps
 `docker-compose -f infrastructure-docker-compose.yml up -d`  
 `docker-compose -f application-docker-compose.yml up -d`
 
-Then point your browser to [http://localhost:3000](http://localhost:3000).
+Then point your browser to [http://localhost:8080](http://localhost:8080).
 
 ![](/assets/keycloak.png)
 


### PR DESCRIPTION
The app listens on 8080, not on 3000.