### PR TITLE
Fix broken link to workshop docs

### DIFF
--- a/blueprints/trending-topic-campaigns.md
+++ b/blueprints/trending-topic-campaigns.md
@@ -6,7 +6,7 @@ Activiti Cloud BluePrints are designed to show users how different business scen
 
 **Workshop** This BluePrint has a workshop associated with it that you can follow to get your Activiti Cloud application deployed in Kubernetes.
 
-### For all the instructions visit: [TTC Docs Workshop](https://github.com/Activiti/ttc-docs/blob/develop/workshop.md)
+### For all the instructions visit: [TTC Docs Workshop](https://github.com/Activiti/ttc-docs/blob/master/workshop.md)
 
 ### Scenario \(The WHAT\)
 


### PR DESCRIPTION
https://activiti.gitbook.io/activiti-7-developers-guide/blueprints/trending-topic-campaigns currently links to a 404