### PR TITLE
3937 fix swagger ui urls

### DIFF
--- a/getting-started/getting-started-activiti-cloud/README.md
+++ b/getting-started/getting-started-activiti-cloud/README.md
@@ -223,9 +223,9 @@ You are now ready to start consuming these services to automate your own busines
 
 Finally, you can access to all services Swagger documentation by pointing your browser to:
 
-* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/rb-my-app/swagger-ui.html](http://activiti-cloud-gateway.external-ip.nip.io/rb-my-app/swagger-ui.html)
-* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/audit/swagger-ui.html](http://activiti-cloud-gateway.external-ip.nip.io/audit/swagger-ui.html)
-* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/query/swagger-ui.html](http://activiti-cloud-gateway.external-ip.nip.io/query/swagger-ui.html)
+* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/rb-my-app/swagger-ui/index.html](http://activiti-cloud-gateway.external-ip.nip.io/rb-my-app/swagger-ui/index.html)
+* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/audit/swagger-ui/index.html](http://activiti-cloud-gateway.external-ip.nip.io/audit/swagger-ui/index.html)
+* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/query/swagger-ui/index.html](http://activiti-cloud-gateway.external-ip.nip.io/query/swagger-ui/index.html)
 
 ![](../../.gitbook/assets/screenshot-2018-12-13-at-11.21.47.png)
 

--- a/getting-started/getting-started-activiti-cloud/README.md
+++ b/getting-started/getting-started-activiti-cloud/README.md
@@ -223,7 +223,7 @@ You are now ready to start consuming these services to automate your own busines
 
 Finally, you can access to all services Swagger documentation by pointing your browser to:
 
-* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/rb-my-app/swagger-ui/index.html](http://activiti-cloud-gateway.external-ip.nip.io/rb-my-app/swagger-ui/index.html)
+* [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/rb/swagger-ui/index.html](http://activiti-cloud-gateway.external-ip.nip.io/rb/swagger-ui/index.html)
 * [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/audit/swagger-ui/index.html](http://activiti-cloud-gateway.external-ip.nip.io/audit/swagger-ui/index.html)
 * [http://activiti-cloud-gateway.EXTERNAL-IP.nip.io/query/swagger-ui/index.html](http://activiti-cloud-gateway.external-ip.nip.io/query/swagger-ui/index.html)
 


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/3937

The swagger-ui url changed from /swagger-ui.html to /swagger-ui/index.html after migration from Springfox to Springdoc. This should be reflected in the documentation.

